### PR TITLE
Remove environment protection from GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,9 +54,6 @@ jobs:
           path: tep-oncology-site/build
 
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Remove the github-pages environment configuration that was blocking deployments due to protection rules. The workflow will now deploy directly without environment restrictions.