### PR TITLE
Update course platform after first launch

### DIFF
--- a/tep-oncology-site/src/pages/index.js
+++ b/tep-oncology-site/src/pages/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import {Redirect} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 export default function Home() {
-  return <Redirect to="/docs/intro" />;
+  const docsUrl = useBaseUrl('/docs/intro');
+  return <Redirect to={docsUrl} />;
 }


### PR DESCRIPTION
La page d'accueil redirige maintenant correctement vers /docs/intro en respectant le baseUrl (/oncopet_academy/). Utilisation de useBaseUrl pour générer l'URL correcte qui prend en compte la configuration du site.

Résout le problème où la redirection pointait vers https://lescientifik.github.io/docs/intro au lieu de https://lescientifik.github.io/oncopet_academy/docs/intro