### PR TITLE
Ajout cours pratique : TEP-FDG hyperglycémie vs effet insulinique

### DIFF
--- a/tep-oncology-site/docs/intro.md
+++ b/tep-oncology-site/docs/intro.md
@@ -44,6 +44,7 @@ L'objectif est de construire progressivement **une base de connaissances complè
 
 - **[Guide de rédaction - Comptes rendus TEP-scan](./pratique/redaction-comptes-rendus-tep.md)** : guide complet pour la rédaction des comptes rendus (critères PERCIST, score de Deauville, bonnes pratiques)
 - **[Critères RECIST 1.1 et PERCIST 1.0](./pratique/criteres-recist-percist.md)** : cours comparatif sur l'évaluation de la réponse thérapeutique — critères anatomiques (RECIST) vs métaboliques (PERCIST), concepts de baseline, nadir, réponse et progression
+- **[TEP-FDG : hyperglycémie vs effet insulinique](./pratique/tep-fdg-hyperglycemie-insuline.md)** : synthèse fondée sur les preuves (EBM) des effets de l'hyperglycémie à jeun et de l'insuline sur la biodistribution du FDG (captation cérébrale, musculaire, hépatique, SUV tumoral) et conduite à tenir selon l'EANM
 
 ### Guidelines & Recommandations
 

--- a/tep-oncology-site/docs/pratique/tep-fdg-hyperglycemie-insuline.md
+++ b/tep-oncology-site/docs/pratique/tep-fdg-hyperglycemie-insuline.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 3
+title: "TEP-FDG : hyperglycémie vs effet insulinique"
+description: "Synthèse fondée sur les preuves (EBM) des effets de l'hyperglycémie à jeun et de l'insuline sur la biodistribution du [18F]FDG : captation cérébrale, musculaire, hépatique, SUV tumoral et conduite à tenir selon l'EANM"
+authors:
+  - name: Dr T. Henry
+    role: Médecin nucléaire
+  - name: Claude
+    role: Assistant IA
+---
+
+import HyperglycemieInsuline from '@site/src/components/HyperglycemieInsuline';
+
+# TEP-FDG : hyperglycémie vs effet insulinique — synthèse fondée sur les preuves
+
+---
+
+## 1. Pourquoi distinguer les deux situations ?
+
+En pratique, deux mécanismes très différents sont souvent confondus lorsqu'on
+parle de « glycémie élevée » avant une TEP-FDG :
+
+- **L'hyperglycémie à jeun** : l'insulinémie reste basse. Le glucose endogène
+  entre en **compétition** avec le FDG pour les transporteurs GLUT et
+  l'hexokinase.
+- **L'effet insulinique** (insuline injectée *ou* repas récent / non-jeûne) :
+  l'insuline provoque une **translocation des transporteurs GLUT4** vers les
+  tissus non tumoraux (muscle, graisse), détournant le FDG de la tumeur.
+
+Ces deux situations n'ont ni les mêmes conséquences sur les images, ni la même
+conduite à tenir. Le tableau ci-dessous synthétise les données après analyse
+critique de la littérature.
+
+## 2. Tableau de synthèse
+
+<HyperglycemieInsuline />
+
+:::tip Points clés
+- L'**hyperglycémie à jeun n'est pas une contre-indication absolue** : sous
+  200 mg/dL, pas d'effet significatif démontré sur le SUV tumoral (Eskian 2018).
+- **Ne jamais injecter d'insuline** pour corriger la glycémie avant l'examen :
+  cela dégrade l'image par captation musculaire/graisseuse diffuse (EANM).
+- Respecter le **jeûne ≥ 4 h** et viser une glycémie de **4–7 mmol/L** ; noter
+  la glycémie mesurée pour l'interprétation.
+- Au-delà de **200 mg/dL**, prudence : baisse possible du SUV et du contraste
+  tumeur/fond.
+:::
+
+---
+
+## Références
+
+1. <a id="ref-1"></a>Boellaard R, Delgado-Bolton R, Oyen WJG, et al. FDG PET/CT:
+   EANM procedure guidelines for tumour imaging: version 2.0. *Eur J Nucl Med Mol
+   Imaging*. 2015;42(2):328-354.
+   [PubMed](https://pubmed.ncbi.nlm.nih.gov/25452219/)
+2. <a id="ref-2"></a>Eskian M, Alavi A, Khorasanizadeh M, et al. Effect of blood
+   glucose level on standardized uptake value (SUV) in 18F-FDG PET-scan: a
+   systematic review and meta-analysis of 20,807 individual SUV measurements.
+   *Eur J Nucl Med Mol Imaging*. 2019;46(1):224-237.
+   [PubMed](https://pubmed.ncbi.nlm.nih.gov/30137513/)
+3. <a id="ref-3"></a>Büsing KA, Schönberg SO, Brade J, Wasser K. Impact of blood
+   glucose, diabetes, insulin, and obesity on standardized uptake values in
+   tumors and healthy organs on 18F-FDG PET/CT. *Nucl Med Biol*.
+   2013;40(2):206-213.
+   [PubMed](https://pubmed.ncbi.nlm.nih.gov/23194674/)
+4. <a id="ref-4"></a>Rosica D, Cheng SC, Hudson J, et al. Effect of blood glucose
+   level on standardized uptake value of normal organs in 18F-FDG PET/CT.
+   *Nucl Med Commun*. 2018;39(5):417-422.
+   [PubMed](https://pubmed.ncbi.nlm.nih.gov/29465432/)
+5. <a id="ref-5"></a>Diederichs CG, Staib L, Glatting G, Beger HG, Reske SN.
+   FDG PET: elevated plasma glucose reduces both uptake and detection rate of
+   pancreatic malignancies. *J Nucl Med*. 1998;39(6):1030-1033.
+   [PubMed](https://pubmed.ncbi.nlm.nih.gov/9627339/)
+6. <a id="ref-6"></a>Hofman MS, Hicks RJ. Effect of intravenous insulin on the
+   biodistribution of 18F-FDG. *EJNMMI Res*. 2011;1(1):2.
+   [PubMed](https://pubmed.ncbi.nlm.nih.gov/22214497/)

--- a/tep-oncology-site/src/components/HyperglycemieInsuline/index.tsx
+++ b/tep-oncology-site/src/components/HyperglycemieInsuline/index.tsx
@@ -1,0 +1,349 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+const DOI_ESKIAN = 'https://doi.org/10.1007/s00259-018-4194-x';
+const DOI_BUSING = 'https://doi.org/10.1016/j.nucmedbio.2012.10.014';
+const DOI_EANM_V2 = 'https://doi.org/10.1007/s00259-014-2961-x';
+const URL_EANM_V3 = 'https://www.sciencedirect.com/science/article/pii/S3051292125000065';
+
+type RefProps = { href: string; children: React.ReactNode };
+const Ref = ({ href, children }: RefProps) => (
+  <a className={styles.ref} href={href} target="_blank" rel="noopener noreferrer">
+    {children}
+  </a>
+);
+
+export default function HyperglycemieInsuline(): JSX.Element {
+  return (
+    <div className={styles.wrap}>
+      <p className={styles.subtitle}>
+        Tableau simplifié après analyse critique : ne sont conservées que les
+        affirmations soutenues par la méta-analyse sur données individuelles
+        (Eskian 2018) et/ou les recommandations EANM. Les conclusions reposant
+        uniquement sur un case report (n=1) ou un micro-sous-groupe ancien ont
+        été retirées ou requalifiées.
+      </p>
+
+      <div className={styles.evidenceLegend}>
+        <strong>Niveau de preuve par ligne (gradation simplifiée)</strong>
+        <span className={`${styles.evBadge} ${styles.evSolid}`}>SOLIDE</span>
+        méta-analyse de données individuelles + guideline EANM concordantes
+        &nbsp;·&nbsp;
+        <span className={`${styles.evBadge} ${styles.evModerate}`}>MODÉRÉ</span>
+        méta-analyse seule ou séries rétrospectives concordantes &nbsp;·&nbsp;
+        <span className={`${styles.evBadge} ${styles.evWeak}`}>FAIBLE</span>
+        case report / sous-groupe limité / extrapolation
+      </div>
+
+      <div className={styles.legend}>
+        <span>
+          <span className={styles.dot} style={{ background: 'var(--hp-hyper)' }} />
+          Hyperglycémie à jeun
+        </span>
+        <span>
+          <span className={styles.dot} style={{ background: 'var(--hp-insulin)' }} />
+          Effet insulinique (exogène ou endogène)
+        </span>
+        <span>
+          <span className={styles.arrowUp}>↑</span> augmentée &nbsp;
+          <span className={styles.arrowDown}>↓</span> diminuée
+        </span>
+      </div>
+
+      <div className={styles.tableScroll}>
+        <table className={styles.table}>
+          <thead>
+            <tr className={styles.braceRow}>
+              <th />
+              <th />
+              <th className={styles.braceCell}>
+                <span className={styles.braceLabel}>
+                  Même mécanisme : insuline → translocation de GLUT4 vers les
+                  tissus non tumoraux
+                </span>
+                <span className={styles.braceShape} aria-hidden="true" />
+              </th>
+            </tr>
+            <tr>
+              <th className={styles.colParam}>Paramètre</th>
+              <th className={styles.colHyper}>
+                Hyperglycémie à jeun
+                <span className={styles.mech}>
+                  Compétition glucose/FDG pour GLUT &amp; hexokinase
+                  (insulinémie basse)
+                </span>
+              </th>
+              <th className={styles.colInsulin}>
+                Effet insulinique
+                <br />
+                (insuline injectée <em>ou</em> repas récent / non-jeûne)
+                <span className={styles.mech}>
+                  Insuline exogène ou endogène post-prandiale
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>Captation cérébrale</th>
+              <td>
+                <span className={styles.arrowDown}>↓↓</span> Diminuée{' '}
+                <span className={`${styles.evTag} ${styles.evSolid}`}>SOLIDE</span>
+                <br />
+                <Ref href={DOI_ESKIAN}>Eskian 2018</Ref>
+              </td>
+              <td>
+                <span className={styles.arrowDown}>↓</span> Diminuée (le glucose
+                entré reste capté en périphérie)
+                <br />
+                <Ref href={DOI_ESKIAN}>Eskian 2018</Ref>
+              </td>
+            </tr>
+            <tr>
+              <th>Muscle squelettique</th>
+              <td>
+                <span className={styles.arrowUp}>↑</span> Légèrement augmentée{' '}
+                <span className={`${styles.evTag} ${styles.evModerate}`}>
+                  MODÉRÉ
+                </span>
+                <br />
+                <Ref href={DOI_ESKIAN}>Eskian 2018</Ref>
+              </td>
+              <td>
+                <span className={styles.arrowUp2}>↑↑↑</span> Fortement augmentée,
+                diffuse{' '}
+                <span className={`${styles.evTag} ${styles.evSolid}`}>SOLIDE</span>
+                <br />
+                <Ref href={DOI_BUSING}>Büsing 2012</Ref>
+                <Ref href={DOI_EANM_V2}>EANM</Ref>
+              </td>
+            </tr>
+            <tr>
+              <th>Foie / blood pool</th>
+              <td>
+                <span className={styles.arrowUp}>↑</span> Augmentés{' '}
+                <span className={`${styles.evTag} ${styles.evModerate}`}>
+                  MODÉRÉ
+                </span>
+                <br />
+                <Ref href={DOI_ESKIAN}>Eskian 2018</Ref>
+              </td>
+              <td>
+                Effet non clairement établi{' '}
+                <span className={`${styles.evTag} ${styles.evWeak}`}>FAIBLE</span>
+                <span className={styles.muted}> (données insuffisantes)</span>
+              </td>
+            </tr>
+            <tr>
+              <th>SUV tumoral</th>
+              <td>
+                Pas d'effet significatif &lt; 200 mg/dL ; ↓ seulement &gt; 200
+                mg/dL{' '}
+                <span className={`${styles.evTag} ${styles.evSolid}`}>SOLIDE</span>
+                <br />
+                <Ref href={DOI_ESKIAN}>Eskian 2018</Ref>
+              </td>
+              <td>
+                Pas d'amélioration démontrée de la captation tumorale{' '}
+                <span className={`${styles.evTag} ${styles.evModerate}`}>
+                  MODÉRÉ
+                </span>
+                <br />
+                <Ref href={DOI_BUSING}>Büsing 2012</Ref>
+              </td>
+            </tr>
+            <tr>
+              <th>Contraste tumeur / fond &amp; détection</th>
+              <td>
+                Globalement préservé &lt; 200 mg/dL ; prudence si très élevé{' '}
+                <span className={`${styles.evTag} ${styles.evModerate}`}>
+                  MODÉRÉ
+                </span>
+                <br />
+                <Ref href={URL_EANM_V3}>EANM v3.0</Ref>
+              </td>
+              <td>
+                <span className={styles.arrowDown}>↓↓</span> Dégradé par le fond
+                musculaire/graisseux{' '}
+                <span className={`${styles.evTag} ${styles.evSolid}`}>SOLIDE</span>
+                <br />
+                <Ref href={URL_EANM_V3}>EANM v3.0</Ref>
+              </td>
+            </tr>
+            <tr className={styles.practical}>
+              <th>Conduite recommandée (EANM)</th>
+              <td>
+                Jeûne ≥ 4 h ; viser 4–7 mmol/L. Hyperglycémie à jeun = <em>pas</em>{' '}
+                une contre-indication absolue ; noter la glycémie pour
+                l'interprétation
+              </td>
+              <td>
+                Ne <strong>pas</strong> injecter d'insuline pour corriger la
+                glycémie ; respecter le jeûne pour garder l'insulinémie basse
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className={styles.cites}>
+        <h2>Sources, citations exactes et appréciation critique</h2>
+        <p className={styles.crit}>
+          Classées par niveau de preuve décroissant. Le niveau attribué à chaque
+          ligne du tableau reflète la source la plus solide qui la soutient.
+        </p>
+
+        <div className={styles.citeItem}>
+          <span className={styles.tag}>
+            EANM — Guidelines tumour imaging v2.0 &amp; v3.0
+          </span>{' '}
+          <span className={`${styles.evBadge} ${styles.evSolid}`}>
+            Recommandation d'experts
+          </span>
+          <span className={styles.quote}>
+            v3.0 : « Insulin should not be given to reduce glucose levels (this
+            leads to altered pharmacokinetics and biodistribution, including high
+            muscle uptake of [18F]FDG). » — « fasting hyperglycaemia may not
+            hamper the clinical value of [18F]FDG PET... should not represent an
+            absolute contraindication. »
+          </span>
+          Niveau le plus élevé pour la conduite pratique et le mécanisme
+          insulinique. Fonde la fusion des colonnes insuline exogène/endogène.
+          <br />
+          <a href={URL_EANM_V3} target="_blank" rel="noopener noreferrer">
+            EANM v3.0
+          </a>{' '}
+          &nbsp;·&nbsp;{' '}
+          <a href={DOI_EANM_V2} target="_blank" rel="noopener noreferrer">
+            EANM v2.0 — doi.org/10.1007/s00259-014-2961-x
+          </a>
+        </div>
+
+        <div className={styles.citeItem}>
+          <span className={styles.tag}>Eskian 2018</span>{' '}
+          <span className={`${styles.evBadge} ${styles.evSolid}`}>
+            Méta-analyse données individuelles (n=20 807 SUV)
+          </span>
+          <span className={styles.quote}>
+            « Increased BGL is significantly correlated with decreased SUV in
+            brain and muscle and increased SUV in liver and blood pool... No
+            significant correlation was found between BGL and SUV in tumors...
+            only the hyperglycemic group with BGL &gt; 200 mg/dl had
+            significantly lower SUV. »
+          </span>
+          <strong>Source la plus robuste.</strong> Limite : méta-analyse
+          d'études <em>observationnelles</em> hétérogènes, sans randomisation.
+          Très fiable pour les organes sains ; son résultat clé est{' '}
+          <em>négatif</em> (pas d'effet tumoral sous 200 mg/dL). Eur J Nucl Med
+          Mol Imaging 2018;46(1):224-237.{' '}
+          <a href={DOI_ESKIAN} target="_blank" rel="noopener noreferrer">
+            doi.org/10.1007/s00259-018-4194-x
+          </a>
+        </div>
+
+        <div className={styles.citeItem}>
+          <span className={styles.tag}>Büsing 2012</span>{' '}
+          <span className={`${styles.evBadge} ${styles.evModerate}`}>
+            Série rétrospective monocentrique (n=90)
+          </span>
+          <span className={styles.quote}>
+            « Increased BGLs were associated with decreased cerebral FDG uptake
+            and increased uptake in skeletal muscle. Diabetes and insulin...
+            increased the average SUV(max) in muscle cells and fat... Tumoral
+            uptake was not significantly influenced by BGL, diabetes, insulin,
+            or obesity. »
+          </span>
+          Cohérent avec la méta-analyse mais petit effectif, non randomisé.
+          Soutient (en appoint) l'effet musculaire de l'insuline et l'absence
+          d'effet tumoral. Nucl Med Biol 2012;40(2):206-13.{' '}
+          <a href={DOI_BUSING} target="_blank" rel="noopener noreferrer">
+            doi.org/10.1016/j.nucmedbio.2012.10.014
+          </a>
+        </div>
+
+        <div className={styles.citeItem}>
+          <span className={styles.tag}>Rosica 2018</span>{' '}
+          <span className={`${styles.evBadge} ${styles.evModerate}`}>
+            Série rétrospective monocentrique (n=437)
+          </span>
+          <span className={styles.quote}>
+            « the effects are negligible or mild in most patients with BGL less
+            than 200 mg/dl... decline in brain metabolic activity correlated the
+            most with various BGL. »
+          </span>
+          Renforce le seuil de 200 mg/dL et la prédominance de l'effet cérébral,
+          mais design observationnel monocentrique. Nucl Med Commun
+          2018;39(5):417-422.{' '}
+          <a
+            href="https://doi.org/10.1097/MNM.0000000000000829"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            doi.org/10.1097/MNM.0000000000000829
+          </a>
+        </div>
+
+        <div className={styles.citeItem}>
+          <span className={styles.tag}>Diederichs 1998</span>{' '}
+          <span className={`${styles.evBadge} ${styles.evWeak}`}>
+            Rétrospectif ancien — sous-groupe n=19
+          </span>
+          <span className={styles.quote}>
+            « detection rates... 86% and 42%... if fasted plasma glucose levels
+            were below and above 130 mg/dl... Negative PET results... should be
+            interpreted with caution. »
+          </span>
+          <strong>Écarté des conclusions quantitatives du tableau.</strong>{' '}
+          Chiffres frappants mais fondés sur 19 patients seulement, technologie
+          pré-PET/CT (1998), monocentrique. Ne sert qu'à appuyer une prudence
+          qualitative — déjà couverte par l'EANM. J Nucl Med 1998;39(6):1030-3.{' '}
+          <a
+            href="https://pubmed.ncbi.nlm.nih.gov/9627339/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            PMID 9627339
+          </a>
+        </div>
+
+        <div className={styles.citeItem}>
+          <span className={styles.tag}>Hofman 2011</span>{' '}
+          <span className={`${styles.evBadge} ${styles.evWeak}`}>
+            Case report (n=1)
+          </span>
+          <span className={styles.quote}>
+            « Prominent diffuse white adipose tissue, gastric mucosal,
+            myocardial, and very low hepatic and muscle activity were observed. »
+          </span>
+          <strong>
+            Retiré des cellules « myocarde », « graisse » et « foie bas » du
+            tableau.
+          </strong>{' '}
+          Niveau de preuve le plus faible (1 patient). Illustratif du mécanisme
+          insulinique mais non généralisable ; redondant avec l'EANM qui établit
+          déjà la captation musculaire induite par l'insuline. EJNMMI Res
+          2011;1(1):2.{' '}
+          <a
+            href="https://doi.org/10.1186/2191-219X-1-2"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            doi.org/10.1186/2191-219X-1-2
+          </a>
+        </div>
+      </div>
+
+      <p className={styles.sourceNote}>
+        Principales modifications après lecture critique : (1) la colonne « SUV
+        tumoral » indique désormais l'<em>absence</em> d'effet significatif sous
+        200 mg/dL (résultat le plus solide, Eskian + EANM), corrigeant la version
+        précédente qui suggérait une baisse ; (2) lignes « myocarde » et « graisse
+        exogène » supprimées car reposant sur un case report ; (3) chiffres de
+        détection pancréatique (Diederichs) retirés du corps du tableau et
+        requalifiés en prudence qualitative ; (4) colonnes insuline
+        exogène/endogène fusionnées, conformément au mécanisme GLUT4 commun
+        explicité par l'EANM. Données issues de PubMed et des guidelines EANM.
+      </p>
+    </div>
+  );
+}

--- a/tep-oncology-site/src/components/HyperglycemieInsuline/styles.module.css
+++ b/tep-oncology-site/src/components/HyperglycemieInsuline/styles.module.css
@@ -1,0 +1,295 @@
+/* Synthèse EBM : TEP-FDG hyperglycémie vs effet insulinique.
+   Palette alignée sur la charte du site (bleu santé) + support du thème sombre. */
+
+.wrap {
+  --hp-accent: var(--ifm-color-primary);
+  --hp-hyper: #c2410c;
+  --hp-insulin: #7c3aed;
+  --hp-solid: #2e7d5b;
+  --hp-moderate: #b7891b;
+  --hp-weak: #c0504d;
+
+  --hp-card: var(--ifm-background-surface-color);
+  --hp-line: var(--ifm-color-emphasis-200);
+  --hp-row-head: var(--ifm-color-emphasis-100);
+  --hp-cite-bg: var(--ifm-color-emphasis-100);
+  --hp-muted: var(--ifm-color-emphasis-600);
+  --hp-shadow: 0 1px 3px rgba(20, 40, 60, 0.08);
+
+  margin: 0 0 1rem;
+}
+
+[data-theme='dark'] .wrap {
+  --hp-hyper: #f97316;
+  --hp-insulin: #a78bfa;
+  --hp-solid: #43b27a;
+  --hp-moderate: #d4af37;
+  --hp-weak: #e57373;
+  --hp-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+.subtitle {
+  color: var(--hp-muted);
+  font-size: 0.92rem;
+  margin: 0 0 1.4rem;
+}
+
+/* Légende des niveaux de preuve */
+.evidenceLegend {
+  background: var(--hp-card);
+  border: 1px solid var(--hp-line);
+  border-radius: 10px;
+  padding: 12px 16px;
+  margin-bottom: 18px;
+  font-size: 0.8rem;
+  box-shadow: var(--hp-shadow);
+}
+
+.evidenceLegend strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 0.85rem;
+}
+
+.evBadge {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 4px;
+  color: #fff;
+  margin-right: 4px;
+}
+
+.evSolid { background: var(--hp-solid); }
+.evModerate { background: var(--hp-moderate); }
+.evWeak { background: var(--hp-weak); }
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 14px;
+  font-size: 0.82rem;
+}
+
+.legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  display: inline-block;
+}
+
+/* Tableau */
+.tableScroll {
+  overflow-x: auto;
+  border-radius: 12px;
+  box-shadow: var(--hp-shadow);
+  border: 1px solid var(--hp-line);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--hp-card);
+  min-width: 760px;
+  margin: 0;
+}
+
+.table thead th {
+  text-align: left;
+  padding: 13px 15px;
+  font-size: 0.88rem;
+  color: #fff;
+  vertical-align: top;
+  border: none;
+}
+
+.colParam { background: var(--hp-accent); }
+.colHyper { background: var(--hp-hyper); }
+.colInsulin { background: var(--hp-insulin); }
+
+.mech {
+  display: block;
+  font-weight: 400;
+  font-size: 0.76rem;
+  opacity: 0.92;
+  margin-top: 3px;
+}
+
+/* Accolade « même mécanisme » */
+.braceRow th {
+  padding: 0;
+  background: transparent;
+  border: none;
+}
+
+.braceCell {
+  position: relative;
+  background: transparent;
+  padding: 0 0 6px;
+}
+
+.braceLabel {
+  display: block;
+  text-align: center;
+  color: var(--hp-insulin);
+  font-weight: 600;
+  font-size: 0.8rem;
+  padding: 8px 12px 6px;
+}
+
+.braceShape {
+  display: block;
+  height: 12px;
+  margin: 0 10px;
+  border: 2px solid var(--hp-insulin);
+  border-bottom: none;
+  border-radius: 10px 10px 0 0;
+  position: relative;
+}
+
+.braceShape::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -8px;
+  transform: translateX(-50%);
+  width: 2px;
+  height: 8px;
+  background: var(--hp-insulin);
+}
+
+.table tbody th {
+  text-align: left;
+  padding: 12px 15px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: var(--hp-row-head);
+  color: var(--ifm-font-color-base);
+  vertical-align: top;
+  border-bottom: 1px solid var(--hp-line);
+}
+
+.table tbody td {
+  padding: 12px 15px;
+  font-size: 0.85rem;
+  border-bottom: 1px solid var(--hp-line);
+  vertical-align: top;
+  color: var(--ifm-font-color-base);
+}
+
+.table tbody tr:last-child td,
+.table tbody tr:last-child th {
+  border-bottom: none;
+}
+
+.arrowUp { color: var(--hp-hyper); font-weight: 700; }
+.arrowUp2 { color: var(--hp-insulin); font-weight: 700; }
+.arrowDown { color: var(--hp-accent); font-weight: 700; }
+
+.ref {
+  display: inline-block;
+  font-size: 0.7rem;
+  background: var(--hp-cite-bg);
+  border: 1px solid var(--hp-line);
+  border-radius: 4px;
+  padding: 1px 5px;
+  margin-top: 4px;
+  margin-right: 3px;
+  color: var(--hp-accent);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.ref:hover {
+  background: var(--hp-accent);
+  color: #fff;
+}
+
+.evTag {
+  display: inline-block;
+  font-size: 0.64rem;
+  font-weight: 700;
+  padding: 0 5px;
+  border-radius: 3px;
+  color: #fff;
+  vertical-align: middle;
+}
+
+.muted { color: var(--hp-muted); }
+
+.practical td,
+.practical th {
+  background: color-mix(in srgb, var(--hp-accent) 8%, var(--hp-card));
+  font-weight: 500;
+}
+
+/* Bloc citations */
+.cites {
+  margin-top: 30px;
+  background: var(--hp-card);
+  border: 1px solid var(--hp-line);
+  border-radius: 12px;
+  padding: 20px 24px;
+  box-shadow: var(--hp-shadow);
+}
+
+.cites h2 {
+  font-size: 1.05rem;
+  margin: 0 0 6px;
+}
+
+.crit {
+  font-size: 0.82rem;
+  color: var(--hp-muted);
+  margin: 0 0 14px;
+}
+
+.citeItem {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--hp-line);
+  font-size: 0.84rem;
+}
+
+.citeItem:last-child { border-bottom: none; }
+
+.citeItem .tag {
+  display: inline-block;
+  font-weight: 700;
+  color: var(--hp-accent);
+  margin-right: 6px;
+}
+
+.quote {
+  display: block;
+  font-style: italic;
+  color: var(--hp-muted);
+  margin: 6px 0;
+  padding-left: 12px;
+  border-left: 3px solid var(--hp-line);
+}
+
+.citeItem a {
+  color: var(--hp-accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.citeItem a:hover { text-decoration: underline; }
+
+.sourceNote {
+  margin-top: 16px;
+  font-size: 0.78rem;
+  color: var(--hp-muted);
+}
+
+@media (max-width: 600px) {
+  .cites { padding: 16px; }
+}


### PR DESCRIPTION
## Résumé

Intègre la synthèse EBM **« TEP-FDG : hyperglycémie vs effet insulinique »** (fournie initialement sous forme de fichier HTML autonome) comme cours du site, en respectant l'architecture Docusaurus et la charte graphique.

La page sera accessible sous **Pratique clinique → TEP-FDG : hyperglycémie vs effet insulinique** (`/docs/pratique/tep-fdg-hyperglycemie-insuline`).

## Changements

- **`src/components/HyperglycemieInsuline/index.tsx`** — tableau comparatif + bloc citations convertis en composant React.
- **`src/components/HyperglycemieInsuline/styles.module.css`** — styles en CSS module (scoping propre).
- **`docs/pratique/tep-fdg-hyperglycemie-insuline.md`** — page de cours qui embarque le composant : frontmatter, intro pédagogique, encart « Points clés », références Vancouver + liens PubMed selon le template du projet.
- **`docs/intro.md`** — lien ajouté dans la section « Pratique clinique ».

## Adaptations charte graphique

- Colonne « Paramètre » et liens passés au **bleu santé du site** (`--ifm-color-primary`, `#0077B6`).
- Couleurs **sémantiques** conservées (orange = hyperglycémie, violet = effet insulinique, badges vert/ambre/rouge pour les niveaux de preuve), mais harmonisées.
- **Support du thème sombre** ajouté (variables Infima + teintes ajustées en dark mode), absent du HTML d'origine.
- Accolade « même mécanisme », badges, légende et cartes de citation préservés.

## Vérification

- `bun run build` passe (`[SUCCESS]`), page bien générée (`build/docs/pratique/tep-fdg-hyperglycemie-insuline.html`).
- Les warnings d'ancres affichés au build concernent d'autres pages préexistantes, pas celle-ci.

## À valider

- ⚠️ Contenu médical à relire/valider par Dr T. Henry avant merge.

https://claude.ai/code/session_01UBT9VakzeETk2b47gp38nj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBT9VakzeETk2b47gp38nj)_